### PR TITLE
adding explicit cast to u_int32_t for arc4random_uniform

### DIFF
--- a/NSMutableArray+Shuffle.m
+++ b/NSMutableArray+Shuffle.m
@@ -16,7 +16,7 @@
     for (NSUInteger i = 0; i < count; ++i) {
         // Select a random element between i and end of array to swap with.
         NSInteger nElements = count - i;
-        NSInteger n = arc4random_uniform(nElements) + i;
+        NSInteger n = arc4random_uniform((u_int32_t)nElements) + i;
         [self exchangeObjectAtIndex:i withObjectAtIndex:n];
     }
 }


### PR DESCRIPTION
See http://stackoverflow.com/questions/23725579/arc4random-uniform-64-bit-ios for more explanation of this fix.
